### PR TITLE
ci: switch runners from ubicloud to ubuntu-24.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, 'skip build')
     permissions: write-all
-    runs-on: ubicloud-standard-16
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
             ghcr.io/renlabs-dev/torus-docs:${{ env.SANITIZED_REF }}
 
   clean-stale:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/renlabs-dev/devops-ci:latest
 
@@ -88,7 +88,7 @@ jobs:
 
   deploy:
     needs: [build, clean-stale]
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-24.04
     environment: ${{ github.ref_name }}
     container:
       image: ghcr.io/renlabs-dev/devops-ci:latest

--- a/.github/workflows/dry-run-build.yml
+++ b/.github/workflows/dry-run-build.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4


### PR DESCRIPTION
Ubicloud runners are no longer available, so the workflows were silently skipped after the repo-level Actions toggle was disabled. Match the runner choice the rest of renlabs-dev uses (torus-ts).